### PR TITLE
next from 15.5.7 to 15.5.9 / react 19.2.3に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dayjs": "1.11.7",
         "globals": "16.3.0",
         "microcms-js-sdk": "3.2.0",
-        "next": "15.5.7",
+        "next": "15.5.9",
         "nodemailer": "7.0.11",
         "nuqs": "2.5.1",
         "react": "19.2.3",
@@ -2011,9 +2011,9 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
-      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -9462,12 +9462,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
-      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.7",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dayjs": "1.11.7",
     "globals": "16.3.0",
     "microcms-js-sdk": "3.2.0",
-    "next": "15.5.7",
+    "next": "15.5.9",
     "nodemailer": "7.0.11",
     "nuqs": "2.5.1",
     "react": "19.2.3",


### PR DESCRIPTION
- **build(deps): bump next from 15.5.7 to 15.5.9**
- **react 19.2.3に更新**

## 概要

- このPRは何をしているのか？

## 変更点の詳細

- 具体的な変更点

## チェックリスト

- [ ] テストは通ったか？
- [ ] コードに不具合はないか？

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades Next.js and React, pins a few dependency versions, and updates the lockfile accordingly.
> 
> - **Dependencies**:
>   - Bump `next` from `15.5.7` to `15.5.9`.
>   - Bump `react`/`react-dom` from `19.1.2` to `19.2.3`.
>   - Pin versions (remove carets) for `@next/third-parties`, `globals`, and `@eslint/config-inspector`.
> - **Lockfile**:
>   - Sync `package-lock.json` with the above version changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281f214fa77ac2b9518ba442de25951c56cc2779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->